### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -1,4 +1,4 @@
-##DropDownMenu
+## DropDownMenu
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DropDownMenu-green.svg?style=true)](https://android-arsenal.com/details/1/3803)
 
 
@@ -6,18 +6,18 @@
 筛选器. 尽管之前有很多人写,站在别人基础上重新写了一版,适配各种数据model.
 现在的代码已经很清晰明了,模块分明.
 
-##特点
+## 特点
 1. 使用 Adapter模式 添加筛选器条目.使代码清晰可见,便于维护.
 2. 使用泛型支持各种数据数据model. 提供三种泛型View类, 单列ListView,双列ListView 和 单个GridView, sample中还提供了两个GridView的示例.
 3. 自己写FilterCheckedView,支持checked属性,使用selector就可配置选中样式.配合AbsListView.setChecked()使用
 4. 使用FilterUrl作为中介,toString()方法获取到所拼接url,隔离了数据和View,使代码更清晰.
 
-##ScreenShot
+## ScreenShot
 ![DropDownMenu](images/dropDownMenu.gif "Gif Example")
 
 
 
-##使用
+## 使用
 布局文件
 ```
     <com.baiiu.filter.DropDownMenu

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ I have written it for several times, Now the code is most clearly.
 
 [中文文档](README-cn.md)
 
-##Feature
+## Feature
 1. use Adapter to add the SubDropDownMenu. Override the `getView()` method to supply the wantted view.
 2. use Generic to make all kinds of model(pojo,javabean...) can be used.
 3. use FilterCheckedView which implements `Checkable`, so you can use selector to respond to all user action.
 4. use FilterUrl to save the current choosen data, only override `toString()` you will get the url.
 
-##ScreenShot
+## ScreenShot
 ![DropDownMenu](images/dropDownMenu.gif "Gif Example")
 
 ## Usage 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
